### PR TITLE
Revert "Set correct Data Analytics Client."

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,7 +25,7 @@ logutils==0.3.4.1			 # BSD
 requests==2.17.3            # Apache 2.0
 
 git+https://github.com/edx/django-lang-pref-middleware.git@0.1.0#egg=django-lang-pref-middleware
--e git+https://github.com/Stanford-Online/edx-analytics-data-api-client.git@772d8b6658e05d8e86f8e0b21ee6cd99b0d19630#egg=edx-analytics-data-api-client
+-e git+https://github.com/Stanford-Online/edx-analytics-data-api-client.git@648a6df4a349e3df5740fd4604fc04a695a055c3#egg=edx-analytics-data-api-client
 git+https://github.com/edx/opaque-keys.git@d45d0bd8d64c69531be69178b9505b5d38806ce0#egg=opaque-keys
 # custom opaque-key implementations for ccx
 git+https://github.com/jazkarta/ccx-keys.git@e6b03704b1bb97c1d2f31301ecb4e3a687c536ea#egg=ccx-keys


### PR DESCRIPTION
This reverts commit a37aa8c95d4a55adc16066f27415ae3504989f65.

A combination of factors necessitates this. Upstream don't tag the analytics client for open releases and when they implemented v1 api they broke the v0 api.

All that said, I should have caught this on stage but somehow I didn't.